### PR TITLE
Feat/issue 2 typer cli skeleton

### DIFF
--- a/examples/sample_email.txt
+++ b/examples/sample_email.txt
@@ -1,0 +1,6 @@
+Hi Isabel,
+
+Please review today's daily stand-up notes, summarize them, and email it to Savannah. Please don't forget about this Friday's pizza party.
+
+Best,
+Wilheim

--- a/examples/test_notes.txt
+++ b/examples/test_notes.txt
@@ -1,0 +1,1 @@
+This is just a test.

--- a/src/extractbot/cli.py
+++ b/src/extractbot/cli.py
@@ -1,0 +1,55 @@
+import sys
+import typer
+from typing import Annotated
+from importlib.metadata import version
+from rich.console import Console
+from rich.table import Table
+from enum import StrEnum, auto
+
+__version__ = version('extractbot')
+
+console = Console()
+err_console = Console(stderr=True, style="bold red")
+app = typer.Typer()
+
+def version_callback(value: bool):
+    if value:
+        console.print(f"[green]Extractbot Version: {__version__}[/green]")
+        raise typer.Exit()
+
+
+class Format(StrEnum):
+    TABLE = auto()
+    JSON = auto()
+    MARKDOWN = auto()
+
+@app.callback()
+def main(
+        version: Annotated[bool | None, typer.Option("--version", callback=version_callback, help="Show the version and exit.")] = None):
+    pass
+
+@app.command()
+def parse(path: Annotated[str, typer.Argument()],
+          format: Annotated[Format, typer.Option("--format", help="Format the text as a table, json, or markdown.")] = Format.TABLE):
+    try:
+        if path == "-":
+            data = sys.stdin.read()
+        else:
+            with open(path, 'r') as file:
+                data = file.read()
+    
+    except FileNotFoundError as e:
+        err_console.print(f"Error: {e}")
+        raise typer.Exit(code=1)
+    except PermissionError as e:
+        err_console.print(f"Error: {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        err_console.print(f"Error: {e}")
+        raise typer.Exit(code=1)
+
+    if not data.strip():
+        err_console.print(f"Input is empty")
+        raise typer.Exit(code=1)
+
+    console.print(data)

--- a/src/extractbot/cli.py
+++ b/src/extractbot/cli.py
@@ -1,8 +1,10 @@
 import sys
 import typer
+import json
 from typing import Annotated
 from importlib.metadata import version
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.table import Table
 from enum import StrEnum, auto
 
@@ -52,4 +54,14 @@ def parse(path: Annotated[str, typer.Argument()],
         err_console.print(f"Input is empty")
         raise typer.Exit(code=1)
 
-    console.print(data)
+
+    if format == Format.JSON:
+        result = {"text": data}
+        console.print_json(json.dumps(result))
+    elif format == Format.MARKDOWN:
+        md = Markdown(data)
+        console.print(md)
+    else:
+        table = Table("Text")
+        table.add_row(data)
+        console.print(table)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+from typer.testing import CliRunner
+from extractbot.cli import app
+import json
+runner = CliRunner()
+
+def test_parse():
+    result = runner.invoke(app, ["parse", "examples/test_notes.txt"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert "Text" in result.output
+    assert "This is just a test." in result.output
+
+def test_version():
+    result = runner.invoke(app, "--version")
+    assert "Extractbot Version: 0.1.0" in result.output
+
+def test_error_file_not_found():
+    result = runner.invoke(app, ["parse", "imaginary_text.txt"])
+    assert result.exit_code == 1
+    assert "Error: [Errno 2] No such file or directory: 'imaginary_text.txt'" in result.output
+
+def test_error_empty_file():
+    result = runner.invoke(app, ["parse", "examples/sample_meeting.txt"])
+    assert result.exit_code == 1
+    assert "Input is empty" in result.output
+
+def test_json_format():
+    result = runner.invoke(app, ["parse", "examples/test_notes.txt", "--format", "json"])
+    data = json.loads(result.output)
+    assert result.exit_code == 0
+    assert data["text"] == "This is just a test.\n"
+
+
+def test_markdown_format():
+    result = runner.invoke(app, ["parse", "examples/test_notes.txt", "--format", "markdown"])
+    assert result.exit_code == 0
+    assert "This is just a test." in result.output


### PR DESCRIPTION
Adds the extractbot parse command using Typer and Rich. This is the entry point for all future extraction functionality.

**Key decisions:**
- Used @app.callback() for --version so it lives on the main app, not on parse
- Used a StrEnum for --format so Typer validates input automatically and shows valid choices in --help
- Error handling covers file not found, permission denied, and empty input — all exit with code 1

**To test manually:**
```
extractbot parse examples/sample_email.txt
extractbot parse examples/sample_email.txt --format json
extractbot parse examples/sample_email.txt --format markdown
cat examples/sample_email.txt | extractbot parse -
extractbot --version
extractbot --help
```
Closes #2