### PR TITLE
feat: add EXTRACTION_TOOL dict and detailed system prompt

### DIFF
--- a/src/extractbot/extractor.py
+++ b/src/extractbot/extractor.py
@@ -1,0 +1,60 @@
+from datetime import date
+
+today = date.today()
+
+EXTRACTION_TOOL = {
+        "name": "extract_tasks",
+        "description": "Extracts tasks from emails, meeting transcripts, or Slack messages.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string", 
+                                "description": "Title of the extracted task."
+                                },
+                            "description": {
+                                "type": "string", 
+                                "description": "Optional explanation or context of task."
+                                },
+                            "assignee_hint": {
+                                "type": "string", 
+                                "description": "Hint indicating who is responsible for a task if identifiable."
+                                },
+                            "deadline_hint": {
+                                "type": "string", 
+                                "description": "Hint describing when the task is due."
+                                },
+                            "urgency": {
+                                "type": "string", 
+                                "enum": ["unknown", "urgent", "not_urgent"], 
+                                "description": "Estimated urgency level derived from the source text."
+                                },
+                            "importance": {
+                                "type": "string", 
+                                "enum": ["unknown", "important", "not_important"], 
+                                "description": "Estimated importance level derived from the source text."
+                                },
+                            "confidence": {
+                                "type": "number", 
+                                "description": "Model confidence score (0.0-1.0) for the extracted task and its classification."
+                                },
+                            },
+                        "required": ["title", "confidence", "urgency", "importance"]
+                        },
+                    },
+                },
+            },
+        }
+
+SYSTEM_PROMPT = f"""You are a task extractor running as a CLI application. When given text files, you will:
+- Extract all action items. Keep the title concise but detailed. If there is more context or additional information, it can be provided in the optional description
+- Identify assignees by name. If no clear assignee is mentioned, return assignee_hint as null. Do not guess.
+- Detect deadlines. Using today's date, {today}, resolve relative dates like 'by Friday' to absolute. If no clear date is mentioned, return deadline_hint as null. Do not guess.
+- Assess urgency/importance from language cues. This information will be used to assign task to a quadrant in the Eisenhower Matrix.
+- Assign a confidence score (0.0-1.0) for the extracted task and its classification.
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_error_file_not_found():
     assert "Error: [Errno 2] No such file or directory: 'imaginary_text.txt'" in result.output
 
 def test_error_empty_file():
-    result = runner.invoke(app, ["parse", "examples/sample_meeting.txt"])
+    result = runner.invoke(app, ["parse", "examples/sample_empty.txt"])
     assert result.exit_code == 1
     assert "Input is empty" in result.output
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,12 @@
+import json
+from extractbot.models import Task
+from extractbot.extractor import EXTRACTION_TOOL
+
+def test_schema_is_json_serializable():
+    json.dumps(EXTRACTION_TOOL)
+
+def test_schema_fields_match_model_fields():
+    schema_fields = set(EXTRACTION_TOOL["parameters"]["properties"]["tasks"]["items"]["properties"].keys())
+    model_fields = set(Task.model_fields.keys())
+
+    assert schema_fields == model_fields


### PR DESCRIPTION
Implemented the extraction tool schema and system prompt used to generate structured `Task` objects from natural language input.

### What was added

* Added the `EXTRACTION_TOOL` schema definition aligned with the `Task` Pydantic model
* Added extraction-focused system prompt instructions describing how task data should be identified and normalized
* Added validation/tests to ensure schema fields stay in sync with `Task.model_fields`
* Included current date context in the system prompt to improve extraction of relative dates like “tomorrow” or “next Friday”

### Why it’s structured this way

The extraction schema mirrors the `Task` model directly so the LLM output can be validated without additional transformation layers. This keeps the extraction pipeline deterministic and reduces schema drift between prompt/tool definitions and application models.

The schema uses nested arrays of objects instead of flattened fields to preserve structured task metadata and make multi-item extraction predictable. This also keeps the output extensible if additional task attributes are introduced later.

The system prompt is intentionally explicit and extraction-oriented rather than conversational. The goal is consistency and parseable output rather than natural dialogue behavior.

### Decisions worth calling out

* Removed `quadrant` from the extraction schema because it is derived/application-level state rather than user-provided information. Keeping it out of extraction avoids hallucinated prioritization data.
* Included today’s date in the prompt to improve temporal resolution for relative date expressions.
* Added schema/model synchronization tests so future changes to the `Task` model fail fast if the extraction schema becomes outdated.

Closes #4
